### PR TITLE
cleanup gemspec

### DIFF
--- a/metaclass.gemspec
+++ b/metaclass.gemspec
@@ -1,20 +1,13 @@
-# -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-require "metaclass/version"
+require "./lib/metaclass/version"
 
-Gem::Specification.new do |s|
-  s.name        = "metaclass"
-  s.version     = Metaclass::VERSION
+Gem::Specification.new "metaclass", Metaclass::VERSION do |s|
   s.authors     = ["James Mead"]
   s.email       = ["james@floehopper.org"]
-  s.homepage    = "http://github.com/floehopper/metaclass"
-  s.summary     = %q{Adds a metaclass method to all Ruby objects}
+  s.homepage    = "https://github.com/floehopper/metaclass"
+  s.summary     = "Adds a metaclass method to all Ruby objects"
   s.license     = "MIT"
 
   s.rubyforge_project = "metaclass"
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  s.files         = `git ls-files lib`.split("\n")
 end


### PR DESCRIPTION
@floehopper
- simplify / reduce redundancy
- include less files so download + install + vendored gem is smaller

(I actually came here to add license to the gemspec, but it was already there, just not released to rubygems :) )
