### PR TITLE
Move to Minitest 5

### DIFF
--- a/metaclass.gemspec
+++ b/metaclass.gemspec
@@ -17,4 +17,6 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+
+  s.add_development_dependency 'minitest'
 end

--- a/test/object_methods_test.rb
+++ b/test/object_methods_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class ObjectMethodsTest < Test::Unit::TestCase
+class ObjectMethodsTest < Minitest::Test
 
   def setup
     @klass = Class.new
@@ -11,7 +11,7 @@ class ObjectMethodsTest < Test::Unit::TestCase
     assert_raises(NoMethodError) { instance.success? }
 
     instance.__metaclass__.class_eval { def success?; true; end }
-    assert_nothing_raised(NoMethodError) { assert instance.success? }
+    assert instance.success?
 
     another_instance = @klass.new
     assert_raises(NoMethodError) { another_instance.success? }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,4 +2,4 @@ require "rubygems"
 require "bundler/setup"
 
 require "metaclass"
-require "test/unit"
+require "minitest/autorun"


### PR DESCRIPTION
This PR updates the test suite to Minitest 5 as `test/unit` is not part of Ruby anymore.