### PR TITLE
Add rake for "bundle exec rake", and add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: ruby
+
+sudo: false
+
+before_install:
+  - gem install bundler
+
+rvm:
+- 2.0.0
+- 2.1.10
+- 2.2.6
+- 2.3.3
+- 2.4.0
+- ruby-head
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "http://rubygems.org"
 
 gemspec
+
+gem 'rake'


### PR DESCRIPTION
I want to suggest below things to improve development environment.

- Enable bundle build in local.
- Enable Travis CI for this repo.

`metaclass` is used as one of the packages used by Rails.
So, I think running Ci is important.

## Development workflow with Bundler

Below kind of flow is typical for development and Travis CI.
I am using Ruby 2.4.0 in this case.

If we do not add `rake` in `Gemfile`,  `bundle exec rake` causes an error with `--path vendor/bundle
`

```
$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]

$ git clone git@github.com:floehopper/metaclass.git

$ cd metaclass

$ bundle install --path vendor/bundle

$ bundle exec rake -T

$ bundle exec rake (or bundle exec rake test)
...
3 runs, 6 assertions, 0 failures, 0 errors, 0 skips
```

## Travis CI and adding ruby-head

I want to suggest using Travis in this package.
I prepared `.travis.yml`.

I want to explain about one good habit.
That is adding `ruby-head` as allow_failures.

I think this is useful.
Because we can prepare before next version Ruby 2.5 release.
Though it might not be useful until the actual preview release.
We can support the next version as faster.

We can see this kind of logic in `rails`, `rspec` and `cucumber` and etc.
I think that is the reason why `rails` and `rspec` can support new version Ruby as faster.

https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

Is it possible to add it?

Thanks.





